### PR TITLE
Added the extra option for the github installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ pip3 install taskwarrior-syncall[notion,google]
 ```
 
 - PyPI (may not contain latest version): `pip3 install --user --upgrade taskwarrior-syncall[notion,google,gkeep]`
-- Github: `pip3 install --user git+https://github.com/bergercookie/taskwarrior-syncall`
+- Github: `pip3 install --user "taskwarrior-syncall[google] @ git+https://github.com/bergercookie/taskwarrior-syncall"`
 - Download and install `devel` branch locally - bleeding edge
 
   ```sh


### PR DESCRIPTION
# Description

I had trouble installing the google extra and, in the current readme, it is not clear how to add extras if you want to install using github. I changed the command to install throught github so that it is clear how to add an extra as well.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I ran the command and I was able to install the library with the extra selected included.

# Checklist:

No code has been changed, only change is in readme.
